### PR TITLE
Fix parent id

### DIFF
--- a/devfile-sample-java-springboot-basic/.devfile/nodevfile.yaml
+++ b/devfile-sample-java-springboot-basic/.devfile/nodevfile.yaml
@@ -9,7 +9,7 @@ metadata:
   attributes:
     alpha.dockerimage-port: 8081
 parent:
-  id: python
+  id: python-basic
   registryUrl: "https://registry.devfile.io"
 components:
   - name: outerloop-build

--- a/devfile-sample-python-basic/.devfile/.nodevfile.yaml
+++ b/devfile-sample-python-basic/.devfile/.nodevfile.yaml
@@ -9,7 +9,7 @@ metadata:
   attributes:
     alpha.dockerimage-port: 8081
 parent:
-  id: python
+  id: python-basic
   registryUrl: "https://registry.devfile.io"
 components:
   - name: outerloop-build


### PR DESCRIPTION
https://registry.devfile.io/devfiles/python is not available anymore. Instead, the id should be python-basic.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>